### PR TITLE
Bump OTP and elixir versions

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,13 +1,13 @@
 # Keep in sync with .circleci/config.yml
 
 # https://github.com/erlang/otp/tags
-erlang_version=28.2
+erlang_version=28.4
 
 # https://github.com/elixir-lang/elixir/tags
-elixir_version=1.19.4
+elixir_version=1.19.5
 
 # https://hub.docker.com/r/hexpm/elixir/tags: find a version supporting the combination above
-alpine_version=3.22.2
+alpine_version=3.21.6
 
 always_build_deps=false
 config_vars_to_export=(SECRET_KEY_BASE AUTH_KEY)


### PR DESCRIPTION
There's a breaking change in here: 
https://github.com/erlang/otp/releases/tag/OTP-28.4 # Potential incompatibilities 
about httpc autoretries. A default changed.

Drafting a PR for inspection.